### PR TITLE
chore: add prepublish script to publish NPM packages under @einsteini…

### DIFF
--- a/einstein-scripts/prepublish.js
+++ b/einstein-scripts/prepublish.js
@@ -1,0 +1,138 @@
+const fs = require('fs')
+
+main().then(packages => {
+  packages.filter(deleteUnusedPackage).forEach(prepareForPublishing)
+})
+
+async function main() {
+  try {
+    return fs.readdirSync('./packages')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+function deleteUnusedPackage(packageName) {
+  if (packageName === '@testing') {
+    return true
+  }
+
+  const usedPackages = [
+    '@tinacms',
+    'react-tinacms-date',
+    'react-tinacms-editor',
+    'react-tinacms-inline',
+    'tinacms',
+  ]
+
+  if (usedPackages.includes(packageName)) {
+    return true
+  }
+
+  // delete directory recursively
+  const dir = `./packages/${packageName}`
+  try {
+    fs.rmSync(dir, { recursive: true })
+  } catch (err) {
+    console.error(err)
+  }
+
+  console.log(`Deleted: ${packageName}`)
+}
+
+function prepareForPublishing(packageName) {
+  if (packageName === '@testing') {
+    return
+  }
+
+  try {
+    if (packageName === '@tinacms') {
+      fs.readdir(`./packages/@tinacms`, 'utf8', (err, files) => {
+        if (err) {
+          throw err
+        }
+
+        files
+          .filter(file => {
+            if (file.startsWith('.')) {
+              return false
+            }
+            return true
+          })
+          .forEach(atTinacmsPackageName => {
+            formatPackageJSON(`@tinacms/${atTinacmsPackageName}`)
+          })
+      })
+
+      return
+    }
+
+    formatPackageJSON(packageName)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+function formatPackageJSON(packageName) {
+  const filePath = `./packages/${packageName}/package.json`
+
+  try {
+    if (!fs.existsSync(filePath)) {
+      return
+    }
+  } catch (err) {
+    console.error(error)
+  }
+
+  // console.log(`\npackages/${packageName}/package.json`)
+
+  let json
+
+  try {
+    json = fs.readFileSync(filePath, 'utf8')
+  } catch (err) {
+    console.error(err)
+  }
+
+  const data = JSON.parse(json)
+
+  // console.log('Updating fields...\n')
+
+  if (packageName.startsWith('@')) {
+    data.name = `@einsteinindustries/${packageName
+      .substring(1)
+      .replace(/\//, '-')}`
+    // console.log(`\t"name": `, data.name)
+  } else {
+    data.name = `@einsteinindustries/${packageName.replace(/\//, '-')}`
+    // console.log(`\t"name": `, data.name)
+  }
+
+  if (data?.keywords) {
+    data.keywords = []
+    // console.log(`\t"keywords: []`)
+  }
+
+  if (data?.bugs?.url) {
+    data.bugs.url = 'https://github.com/einstein/tinacms/issues'
+    // console.log(`\t"bugs": { "url": "${data.bugs.url}" }`)
+  }
+
+  if (data?.repository?.url) {
+    data.repository.url = 'https://github.com/einstein/tinacms.git'
+    // console.log(`\t"repository": { "url": "${data.repository.url}" }`)
+  }
+
+  // console.log(JSON.stringify(data, null, 2))
+
+  try {
+    json = JSON.stringify(data, null, 2) + '\n'
+    fs.writeFileSync(filePath, json)
+  } catch (err) {
+    console.error(err)
+  }
+
+  if (packageName !== data.name) {
+    console.log(`✅ ${packageName} → ${data.name}`)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lerna": "lerna",
     "hard-reset": "npm run nuke && npm run bs && npm run build",
     "test": "lerna run test --reject-cycles",
-    "docs": "lerna run docs"
+    "docs": "lerna run docs",
+    "prepublish": "node ./einstein-scripts/prepublish.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",


### PR DESCRIPTION
- Added `./einstein-scripts/prepublish.js`
- This will run before publishing to NPM with `lerna publish` to ensure that the packages needed will be under the `@einstienindustries` user scope.