### PR TITLE
LUC-1572: Implement 'duplicate' button on group-list items

### DIFF
--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -28,6 +28,7 @@ import { Droppable, Draggable } from 'react-beautiful-dnd'
 import {
   AddIcon,
   DragIcon,
+  DuplicateIcon,
   ReorderIcon,
   TrashIcon,
   LeftArrowIcon,
@@ -144,9 +145,20 @@ interface ItemProps {
 const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
   const FormPortal = useFormPortal()
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
+
   const removeItem = React.useCallback(() => {
     tinaForm.mutators.remove(field.name, index)
   }, [tinaForm, field, index])
+
+  const duplicateItem = React.useCallback(() => {
+    const clonedItem = { ...item }
+    if (clonedItem.name) {
+      clonedItem.name = `${clonedItem.name} (copy)`
+    }
+
+    tinaForm.mutators.insert(field.name, index + 1, clonedItem)
+  }, [tinaForm, field, index, item])
+
   const title = label || (field.label || field.name) + ' Item'
   return (
     <Draggable
@@ -167,6 +179,9 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
             <ItemClickTarget onClick={() => setExpanded(true)}>
               <GroupLabel>{title}</GroupLabel>
             </ItemClickTarget>
+            <DuplicateButton onClick={duplicateItem}>
+              <DuplicateIcon />
+            </DuplicateButton>
             <DeleteButton onClick={removeItem}>
               <TrashIcon />
             </DeleteButton>
@@ -334,6 +349,23 @@ const ItemHeader = styled.div<{ isDragging: boolean }>`
 `
 
 const DeleteButton = styled.button`
+  text-align: center;
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 12px 8px;
+  margin: 0;
+  transition: all 85ms ease-out;
+  svg {
+    transition: all 85ms ease-out;
+  }
+  &:hover {
+    background-color: var(--tina-color-grey-1);
+  }
+`
+
+const DuplicateButton = styled.button`
   text-align: center;
   flex: 0 0 auto;
   border: 0;

--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -152,11 +152,12 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
   }, [tinaForm, field, index])
 
   const duplicateItem = React.useCallback(() => {
-    const clonedItem = {
-      ...item,
+    const deepCopy = JSON.parse(JSON.stringify(item))
+    const newItem = {
+      ...deepCopy,
       name: item.name ? `${item.name} (copy)` : undefined,
     }
-    tinaForm.mutators.insert(field.name, index + 1, clonedItem)
+    tinaForm.mutators.insert(field.name, index + 1, newItem)
   }, [tinaForm, field, index, item])
 
   const title = label || (field.label || field.name) + ' Item'

--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -62,6 +62,7 @@ interface GroupFieldDefinititon extends Field {
      */
     label?: string
   }
+  canCopy?: boolean
 }
 
 interface GroupProps {
@@ -178,9 +179,11 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
             <ItemClickTarget onClick={() => setExpanded(true)}>
               <GroupLabel>{title}</GroupLabel>
             </ItemClickTarget>
-            <DuplicateButton onClick={duplicateItem}>
-              <DuplicateIcon />
-            </DuplicateButton>
+            {field.canCopy && (
+              <DuplicateButton onClick={duplicateItem}>
+                <DuplicateIcon />
+              </DuplicateButton>
+            )}
             <DeleteButton onClick={removeItem}>
               <TrashIcon />
             </DeleteButton>

--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -62,7 +62,7 @@ interface GroupFieldDefinititon extends Field {
      */
     label?: string
   }
-  canCopy?: boolean
+  allowItemDuplication?: boolean
 }
 
 interface GroupProps {
@@ -180,7 +180,7 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
             <ItemClickTarget onClick={() => setExpanded(true)}>
               <GroupLabel>{title}</GroupLabel>
             </ItemClickTarget>
-            {field.canCopy && (
+            {field.allowItemDuplication && (
               <DuplicateButton onClick={duplicateItem}>
                 <DuplicateIcon />
               </DuplicateButton>

--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -153,7 +153,7 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
   const duplicateItem = React.useCallback(() => {
     const clonedItem = {
       ...item,
-      name: item.name ? `${item.name} (copy)` : 'Copied Item',
+      name: item.name ? `${item.name} (copy)` : undefined,
     }
     tinaForm.mutators.insert(field.name, index + 1, clonedItem)
   }, [tinaForm, field, index, item])

--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -151,11 +151,10 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
   }, [tinaForm, field, index])
 
   const duplicateItem = React.useCallback(() => {
-    const clonedItem = { ...item }
-    if (clonedItem.name) {
-      clonedItem.name = `${clonedItem.name} (copy)`
+    const clonedItem = {
+      ...item,
+      name: item.name ? `${item.name} (copy)` : 'Copied Item',
     }
-
     tinaForm.mutators.insert(field.name, index + 1, clonedItem)
   }, [tinaForm, field, index, item])
 

--- a/packages/demo-next/data/index.json
+++ b/packages/demo-next/data/index.json
@@ -12,5 +12,14 @@
       "_template": "cta",
       "text": "Log In"
     }
-  ]
+  ],
+  "rawJson": {
+    "authors": [
+      {
+        "name": "New Author",
+        "id": "f7c6zgwp6",
+        "best-novel": "A Crime Novel"
+      }
+    ]
+  }
 }

--- a/packages/demo-next/pages/index.js
+++ b/packages/demo-next/pages/index.js
@@ -72,6 +72,34 @@ const formOptions = {
       label: 'Home Page Content',
       component: 'markdown',
     },
+    {
+      label: 'Authors List',
+      name: 'rawJson.authors',
+      component: 'group-list',
+      description: 'Authors List',
+      itemProps: item => ({
+        key: item.id,
+        label: item.name,
+      }),
+      defaultItem: () => ({
+        name: 'New Author',
+        id: Math.random()
+          .toString(36)
+          .substr(2, 9),
+      }),
+      fields: [
+        {
+          label: 'Name',
+          name: 'name',
+          component: 'text',
+        },
+        {
+          label: 'Best Novel',
+          name: 'best-novel',
+          component: 'text',
+        },
+      ],
+    },
   ],
   buttons: {
     save: 'capture',

--- a/packages/demo-next/pages/index.js
+++ b/packages/demo-next/pages/index.js
@@ -100,6 +100,35 @@ const formOptions = {
         },
       ],
     },
+    {
+      label: 'Authors List 2 ',
+      name: 'rawJson.authors2',
+      component: 'group-list',
+      description: 'Authors List with copy',
+      itemProps: item => ({
+        key: item.id,
+        label: item.name,
+      }),
+      defaultItem: () => ({
+        name: 'New Author',
+        id: Math.random()
+          .toString(36)
+          .substr(2, 9),
+      }),
+      fields: [
+        {
+          label: 'Name',
+          name: 'name',
+          component: 'text',
+        },
+        {
+          label: 'Best Novel',
+          name: 'best-novel',
+          component: 'text',
+        },
+      ],
+      allowItemDuplication: true,
+    },
   ],
   buttons: {
     save: 'capture',


### PR DESCRIPTION
Within group-list items, this adds a "Duplicate" button next to the "Delete" button. When clicked, a new item appears below it with the same properties but a name that has " (copy)" appended at the end.