### PR TITLE
LUC-1600: Uniquify client assets

### DIFF
--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -45,6 +45,7 @@ export interface MediaRequest {
   onSelect?(media: Media): void
   close?(): void
   allowDelete?: boolean
+  namespace?: string
 }
 
 const StyledTab = styled.button<{ isActive: boolean }>`
@@ -110,6 +111,7 @@ export function MediaPicker({
   allowDelete,
   onSelect,
   close,
+  namespace,
   ...props
 }: MediaRequest) {
   const cms = useCMS()

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -197,12 +197,7 @@ export function MediaPicker({
 
   function refresh() {
     resetOffset()
-    const localStorageKey = `Media-${namespace ?? 'default'}-${currentTab}-${offset ?? 0}-${search}`
-    if (namespace) {
-      localStorage.removeItem(localStorageKey)
-    } else {
-      resetLocalStorage()
-    }
+    resetLocalStorage()
     loadMedia()
   }
 

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -197,7 +197,6 @@ export function MediaPicker({
 
   function refresh() {
     resetOffset()
-    const localStorageKey = `Media-${namespace ?? 'default'}-${currentTab}-${offset ?? 0}-${search}`
     if (namespace) {
       localStorage.removeItem(localStorageKey)
     } else {

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -197,6 +197,7 @@ export function MediaPicker({
 
   function refresh() {
     resetOffset()
+    const localStorageKey = `Media-${namespace ?? 'default'}-${currentTab}-${offset ?? 0}-${search}`
     if (namespace) {
       localStorage.removeItem(localStorageKey)
     } else {

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -143,7 +143,8 @@ export function MediaPicker({
   const [currentTab, setCurrentTab] = useState(0)
   const offset = offsetHistory[offsetHistory.length - 1]
 
-  const localStorageKey = `Media-${currentTab}-${offset ?? 0}-${search}`
+  const localStorageKey = `Media-${namespace ??
+    'default'}-${currentTab}-${offset ?? 0}-${search}`
   const resetOffset = () => setOffsetHistory([])
   const navigateNext = () => {
     if (!list.nextOffset) return

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -197,7 +197,12 @@ export function MediaPicker({
 
   function refresh() {
     resetOffset()
-    resetLocalStorage()
+    const localStorageKey = `Media-${namespace ?? 'default'}-${currentTab}-${offset ?? 0}-${search}`
+    if (namespace) {
+      localStorage.removeItem(localStorageKey)
+    } else {
+      resetLocalStorage()
+    }
     loadMedia()
   }
 

--- a/packages/tinacms/src/plugins/screens/media-manager-screen.tsx
+++ b/packages/tinacms/src/plugins/screens/media-manager-screen.tsx
@@ -20,12 +20,15 @@ import { MediaIcon } from '@einsteinindustries/tinacms-icons'
 import { createScreen } from '@einsteinindustries/tinacms-react-screens'
 import { MediaPicker } from '../../components/media'
 
-export const MediaManagerScreenPlugin = createScreen({
-  name: 'Assets Manager',
-  Component: MediaPicker,
-  Icon: MediaIcon,
-  layout: 'fullscreen',
-  props: {
-    allowDelete: true,
-  },
-})
+export function createMediaManagerScreenPlugin(namespace?: string) {
+  return createScreen({
+    name: 'Assets Manager',
+    Component: MediaPicker,
+    Icon: MediaIcon,
+    layout: 'fullscreen',
+    props: {
+      allowDelete: true,
+      namespace
+    },
+  })
+}

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -49,7 +49,7 @@ import {
   MarkdownFieldPlaceholder,
   HtmlFieldPlaceholder,
 } from './plugins/fields/markdown'
-import { MediaManagerScreenPlugin } from './plugins/screens/media-manager-screen'
+import { createMediaManagerScreenPlugin } from './plugins/screens/media-manager-screen'
 
 const DEFAULT_FIELDS = [
   TextFieldPlugin,
@@ -74,20 +74,25 @@ export interface TinaCMSConfig extends CMSConfig {
   sidebar?: SidebarStateOptions | boolean
   toolbar?: ToolbarStateOptions | boolean
   alerts?: EventsToAlerts
+  namespace?: string
 }
 
 export class TinaCMS extends CMS {
   sidebar?: SidebarState
   toolbar?: ToolbarState
   _alerts?: Alerts
+  namespace?: string
 
   constructor({
     sidebar,
     toolbar,
     alerts = {},
+    namespace,
     ...config
   }: TinaCMSConfig = {}) {
     super(config)
+
+    this.namespace = namespace
 
     this.alerts.setMap({
       'media:upload:failure': () => ({
@@ -116,7 +121,9 @@ export class TinaCMS extends CMS {
         this.fields.add(field)
       }
     })
-    this.plugins.add(MediaManagerScreenPlugin)
+
+    const mediaManagerScreenPlugin = createMediaManagerScreenPlugin(this.namespace)
+    this.plugins.add(mediaManagerScreenPlugin)
   }
 
   get alerts() {


### PR DESCRIPTION
## Summary

This PR introduces an optional `namespace` prop during TinaCMS initialization to isolate media caching between different instances. This is useful in multi-tenant applications where media should not be shared across different clients, such as `lucid-admin`.

## Changes

- Adds an optional `namespace` property to the TinaCMS constructor.
- Modifies the `MediaManagerScreenPlugin` to accept a `namespace` prop through a factory function.
- Passes the `namespace` prop to the `MediaPicker`.

## Impact

With these changes, instances of TinaCMS initialized with different `namespace` values will have isolated media caches. This prevents media from being mistakenly shared or cached between different instances or clients.

## Backward Compatibility

The `namespace` property is optional and the changes are fully backward-compatible.
