### PR TITLE
LUC-1625 & LUC-1607: Removal of default classes

### DIFF
--- a/packages/react-tinacms-editor/src/schema/nodes/heading.ts
+++ b/packages/react-tinacms-editor/src/schema/nodes/heading.ts
@@ -22,7 +22,7 @@ import { getAttrsWith, docAttrs, domAttrs } from './utils'
 export const heading = {
   attrs: {
     level: { default: 1 },
-    class: { default: 'pm-align--left' },
+    class: { default: '' },
     id: { default: '' },
   },
   content: 'inline*',

--- a/packages/react-tinacms-editor/src/schema/nodes/paragraph.ts
+++ b/packages/react-tinacms-editor/src/schema/nodes/paragraph.ts
@@ -23,7 +23,7 @@ export const paragraph = {
   content: 'inline*',
   marks: '_',
   attrs: {
-    class: { default: 'pm-align--left' },
+    class: { default: '' },
     id: { default: '' },
   },
   group: 'block',


### PR DESCRIPTION
When editing richtext, TinaCMS will add a default `pm-align--left` to any non-initialized text it encounters. This causes styling issues. This behavior comes from the ProseMirror schema that is set, and this PR seeks to undo that. 